### PR TITLE
Fix Output Variable related transitions and 9.6 transition

### DIFF
--- a/epjson_transition.spec
+++ b/epjson_transition.spec
@@ -2,7 +2,7 @@
 
 block_cipher = None
 
-a = Analysis(['main.py'],
+a = Analysis(['epjson_transition/main.py'],
              binaries=[],
              datas=[],
              hiddenimports=[],

--- a/epjson_transition/file.py
+++ b/epjson_transition/file.py
@@ -60,7 +60,7 @@ class EpJSONFile:
         logger.add_prefix()
         transitioned_data = transition_instance.transform(transitioned_data, logger)
         logger.remove_prefix()
-        logger.print(f"Writing Updated Output File at {self.output_file_path} (pretend)")
+        logger.print(f"Writing Updated Output File at {self.output_file_path}")
         with self.output_file_path.open('w') as f:
-            f.write(dumps(transitioned_data, indent=2))
+            print(dumps(transitioned_data, indent=4), file=f)
         logger.print("File Transformation Complete")

--- a/epjson_transition/rules/Transition95to96.py
+++ b/epjson_transition/rules/Transition95to96.py
@@ -19,7 +19,12 @@ class EnergyPlus9596(EpJSONTransitionRuleBase):
     def transform(self, file_contents: Dict, logger: SimpleLogger) -> Dict:
         logger.print("Transitioning File Now")
         modified_contents = deepcopy(file_contents)
-        modified_contents["Foo"] = "Bar"
+        # outdoor air sys avail schedule is no longer present, remove that field
+        if 'AirLoopHVAC:OutdoorAirSystem' in modified_contents:
+            systems = modified_contents['AirLoopHVAC:OutdoorAirSystem']
+            for name, system in systems.items():
+                del system['availability_manager_list_name']
+        # done
         return modified_contents
 
     def variable_map(self):
@@ -28,4 +33,4 @@ class EnergyPlus9596(EpJSONTransitionRuleBase):
         or map it to None to delete it, or map it to an array if it should spawn multiple.
         :return:
         """
-        return {'Site Outdoor Air Drybulb Temperature': 'Fake Outdoor DB Temp'}
+        return {}

--- a/epjson_transition/rules/Transition95to96.py
+++ b/epjson_transition/rules/Transition95to96.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict
 
 from epjson_transition.logger import SimpleLogger
@@ -17,8 +18,14 @@ class EnergyPlus9596(EpJSONTransitionRuleBase):
 
     def transform(self, file_contents: Dict, logger: SimpleLogger) -> Dict:
         logger.print("Transitioning File Now")
-        file_contents["Foo"] = "Bar"
-        return file_contents
+        modified_contents = deepcopy(file_contents)
+        modified_contents["Foo"] = "Bar"
+        return modified_contents
 
     def variable_map(self):
+        """
+        Output variable replacements, map each input output variable name to a new name for direct replacement,
+        or map it to None to delete it, or map it to an array if it should spawn multiple.
+        :return:
+        """
         return {'Site Outdoor Air Drybulb Temperature': 'Fake Outdoor DB Temp'}

--- a/epjson_transition/rules/common.py
+++ b/epjson_transition/rules/common.py
@@ -106,8 +106,9 @@ class Version:
         sub_object = epjson_version_object["Version 1"]
         version_id = sub_object["version_identifier"]
         original_version = KnownVersions.version_enum_from_string(version_id)
-        # TODO: Validate original version
+        # TODO: Check if we need to sanitize the version or not here, it may already be done in the Version class
         new_version = KnownVersions.NextVersion[original_version]
         new_version_string = KnownVersions.VersionStrings[new_version]
+        logger.print(f"Changing file version from {version_id} to {new_version_string}")
         file_contents['Version']['Version 1']['version_identifier'] = new_version_string
         return file_contents

--- a/epjson_transition/rules/common.py
+++ b/epjson_transition/rules/common.py
@@ -24,6 +24,7 @@ class OutputVariable:
         if object_name in file_contents:
             objects = file_contents[object_name]
             # replace the output variable name
+            list_of_objects_to_remove = []
             for name, input_object in objects.items():
                 ov_original = input_object[field_key]
                 ov_original_upper = ov_original.upper()
@@ -31,7 +32,7 @@ class OutputVariable:
                     ov_new = self.upper_case_variable_map[ov_original.upper()]
                     if ov_new is None:
                         logger.print(f"Found {object_name} to delete: {ov_original}")
-                        del self.modified_content[object_name][name]
+                        list_of_objects_to_remove.append((object_name, name))
                     elif isinstance(ov_new, list):
                         logger.print(f"Found {object_name} to replace, spawning {len(ov_new)} new {object_name}'s")
                         for i, ov_new_item in enumerate(ov_new):
@@ -39,13 +40,16 @@ class OutputVariable:
                             item_to_copy[field_key] = ov_new_item
                             self.modified_content[object_name][f"{ov_original}_{i + 1}"] = item_to_copy
                         # now delete the parent
-                        del self.modified_content[object_name][name]
+                        list_of_objects_to_remove.append((object_name, name))
                     else:
                         logger.print(f"Found {object_name} to replace, going from {ov_original} to {ov_new}")
                         self.modified_content[object_name][name][field_key] = ov_new
+            for r in list_of_objects_to_remove:
+                del self.modified_content[r[0]][r[1]]
 
     def transform(self, file_contents: Dict, logger: SimpleLogger) -> Dict:
         logger.print("Processing Output Variable Changes")
+        # TODO: I don't think we need a deepcopy here
         self.modified_content = deepcopy(file_contents)
         self.upper_case_variable_map = self._upper_case_variable_map()
         object_name = 'Output:Variable'
@@ -66,7 +70,30 @@ class OutputVariable:
         object_name = 'Output:Meter:Cumulative:MeterFileOnly'
         field_key = 'key_name'
         self.replace_one_variable_type(file_contents, object_name, field_key, logger)
-
+        object_name = 'Output:Table:TimeBins'
+        field_key = 'variable_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        object_name = 'ExternalInterface:FunctionalMockupUnitImport:From:Variable'
+        field_key = 'output_variable_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        object_name = 'ExternalInterface:FunctionalMockupUnitExport:From:Variable'
+        field_key = 'output_variable_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        # TODO: Output:Table:Monthly
+        # TODO: Meter:Custom
+        # TODO: Meter:Custom:Decrement
+        object_name = 'DemandManagerAssignmentList'
+        field_key = 'meter_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        object_name = 'UtilityCost:Tariff'
+        field_key = 'output_meter_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        object_name = 'ElectricLoadCenter:Distribution'
+        field_key = 'generator_track_meter_scheme_meter_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
+        object_name = 'ElectricLoadCenter:Distribution'
+        field_key = 'storage_control_track_meter_name'
+        self.replace_one_variable_type(file_contents, object_name, field_key, logger)
         return self.modified_content
 
 

--- a/epjson_transition/rules/common.py
+++ b/epjson_transition/rules/common.py
@@ -20,31 +20,52 @@ class OutputVariable:
 
     def transform(self, file_contents: Dict, logger: SimpleLogger) -> Dict:
         logger.print("Processing Output Variable Changes")
-        if 'Output:Variable' not in file_contents:
-            return file_contents
-        output_variables = file_contents['Output:Variable']
-        upper_case_variable_map = self._upper_case_variable_map()
         modified_content = deepcopy(file_contents)
-        # replace the output variable name
-        for name, ov in output_variables.items():
-            ov_original = ov['variable_name']
-            ov_original_upper = ov_original.upper()
-            if ov_original_upper in upper_case_variable_map:
-                ov_new = upper_case_variable_map[ov_original.upper()]
-                if ov_new is None:
-                    logger.print(f"Found output variable to delete: {ov_original}")
-                    del modified_content['Output:Variable'][name]
-                elif isinstance(ov_new, list):
-                    logger.print(f"Found output variable to replace, spawning {len(ov_new)} new variables")
-                    for i, ov_new_item in enumerate(ov_new):
-                        item_to_copy = deepcopy(modified_content['Output:Variable'][name])
-                        item_to_copy['variable_name'] = ov_new_item
-                        modified_content['Output:Variable'][f"{ov_original}_{i+1}"] = item_to_copy
-                    # now delete the parent
-                    del modified_content['Output:Variable'][name]
-                else:
-                    logger.print(f"Found output variable to replace, going from {ov_original} to {ov_new}")
-                    modified_content['Output:Variable'][name]['variable_name'] = ov_new
+        upper_case_variable_map = self._upper_case_variable_map()
+        if 'Output:Variable' in file_contents:
+            output_variables = file_contents['Output:Variable']
+            # replace the output variable name
+            for name, ov in output_variables.items():
+                ov_original = ov['variable_name']
+                ov_original_upper = ov_original.upper()
+                if ov_original_upper in upper_case_variable_map:
+                    ov_new = upper_case_variable_map[ov_original.upper()]
+                    if ov_new is None:
+                        logger.print(f"Found output variable to delete: {ov_original}")
+                        del modified_content['Output:Variable'][name]
+                    elif isinstance(ov_new, list):
+                        logger.print(f"Found output variable to replace, spawning {len(ov_new)} new variables")
+                        for i, ov_new_item in enumerate(ov_new):
+                            item_to_copy = deepcopy(modified_content['Output:Variable'][name])
+                            item_to_copy['variable_name'] = ov_new_item
+                            modified_content['Output:Variable'][f"{ov_original}_{i + 1}"] = item_to_copy
+                        # now delete the parent
+                        del modified_content['Output:Variable'][name]
+                    else:
+                        logger.print(f"Found output variable to replace, going from {ov_original} to {ov_new}")
+                        modified_content['Output:Variable'][name]['variable_name'] = ov_new
+        if 'EnergyManagementSystem:Sensor' in file_contents:
+            sensors = file_contents['EnergyManagementSystem:Sensor']
+            for name, sensor in sensors.items():
+                ov_original = sensor['output_variable_or_output_meter_name']
+                ov_original_upper = ov_original.upper()
+                if ov_original_upper in upper_case_variable_map:
+                    ov_new = upper_case_variable_map[ov_original.upper()]
+                    if ov_new is None:
+                        logger.print(f"Found EMS sensor variable to delete: {ov_original}")
+                        del modified_content['EnergyManagementSystem:Sensor'][name]
+                    elif isinstance(ov_new, list):
+                        logger.print(f"Found EMS sensor variable to replace, spawning {len(ov_new)} new sensors")
+                        for i, ov_new_item in enumerate(ov_new):
+                            item_to_copy = deepcopy(modified_content['EnergyManagementSystem:Sensor'][name])
+                            item_to_copy['output_variable_or_output_meter_name'] = ov_new_item
+                            modified_content['EnergyManagementSystem:Sensor'][f"{ov_original}_{i + 1}"] = item_to_copy
+                        # now delete the parent
+                        del modified_content['EnergyManagementSystem:Sensor'][name]
+                    else:
+                        logger.print(f"Found ENS sensor variable to replace, going from {ov_original} to {ov_new}")
+                        modified_content['EnergyManagementSystem:Sensor'][name][
+                            'output_variable_or_output_meter_name'] = ov_new
         return modified_content
 
 

--- a/epjson_transition/rules/common.py
+++ b/epjson_transition/rules/common.py
@@ -1,6 +1,7 @@
 # Contains class(es) that can be reused by each version's transition class
 # These can contain things that are generally common to every version, though they could change occasionally
 
+from copy import deepcopy
 from typing import Dict
 
 from epjson_transition.logger import SimpleLogger
@@ -23,14 +24,27 @@ class OutputVariable:
             return file_contents
         output_variables = file_contents['Output:Variable']
         upper_case_variable_map = self._upper_case_variable_map()
-        modified_content = file_contents
+        modified_content = deepcopy(file_contents)
+        # replace the output variable name
         for name, ov in output_variables.items():
             ov_original = ov['variable_name']
             ov_original_upper = ov_original.upper()
             if ov_original_upper in upper_case_variable_map:
                 ov_new = upper_case_variable_map[ov_original.upper()]
-                logger.print(f"Found output variable to replace, going from {ov_original} to {ov_new}")
-                modified_content['Output:Variable'][name]['variable_name'] = ov_new
+                if ov_new is None:
+                    logger.print(f"Found output variable to delete: {ov_original}")
+                    del modified_content['Output:Variable'][name]
+                elif isinstance(ov_new, list):
+                    logger.print(f"Found output variable to replace, spawning {len(ov_new)} new variables")
+                    for i, ov_new_item in enumerate(ov_new):
+                        item_to_copy = deepcopy(modified_content['Output:Variable'][name])
+                        item_to_copy['variable_name'] = ov_new_item
+                        modified_content['Output:Variable'][f"{ov_original}_{i+1}"] = item_to_copy
+                    # now delete the parent
+                    del modified_content['Output:Variable'][name]
+                else:
+                    logger.print(f"Found output variable to replace, going from {ov_original} to {ov_new}")
+                    modified_content['Output:Variable'][name]['variable_name'] = ov_new
         return modified_content
 
 

--- a/tests/rules/test_Transition95to96.py
+++ b/tests/rules/test_Transition95to96.py
@@ -17,9 +17,22 @@ class TestEPlus9596Rule(unittest.TestCase):
 
     def test_transform(self):
         file_contents = {
-            "Hello": "World"
+            "AirLoopHVAC:OutdoorAirSystem": {
+                "OA Sys 1": {
+                    "availability_manager_list_name": "Outdoor Air 1 Avail List",
+                    "controller_list_name": "OA Sys 1 Controllers",
+                    "outdoor_air_equipment_list_name": "OA Sys 1 Equipment"
+                }
+            }
         }
         t = EnergyPlus9596()
         updated_contents = t.transform(file_contents, self.muted_logger)
-        expected_contents = {'Hello': 'World', 'Foo': 'Bar'}
+        expected_contents = {
+            "AirLoopHVAC:OutdoorAirSystem": {
+                "OA Sys 1": {
+                    "controller_list_name": "OA Sys 1 Controllers",
+                    "outdoor_air_equipment_list_name": "OA Sys 1 Equipment"
+                }
+            }
+        }
         self.assertDictEqual(expected_contents, updated_contents)

--- a/tests/rules/test_common.py
+++ b/tests/rules/test_common.py
@@ -105,6 +105,23 @@ class TestOutputVariableRule(unittest.TestCase):
             'Output:Meter:MeterFileOnly': {'Output:Meter:MeterFileOnly 1': {"key_name": "m"}},
             'Output:Meter:Cumulative': {'Output:Meter:Cumulative 1': {"key_name": "m"}},
             'Output:Meter:Cumulative:MeterFileOnly': {'Output:Meter:Cumulative:MeterFileOnly 1': {"key_name": "m"}},
+            'Output:Table:TimeBins': {'Output:Table:TimeBins 1': {"key_value": "*", 'variable_name': "m"}},
+            'ExternalInterface:FunctionalMockupUnitImport:From:Variable': {
+                'ExternalInterface:FunctionalMockupUnitImport:From:Variable 1': {
+                    "key_value": "*", 'output_variable_name': "m"
+                }
+            },
+            'ExternalInterface:FunctionalMockupUnitExport:From:Variable': {
+                'ExternalInterface:FunctionalMockupUnitExport:From:Variable 1': {
+                    "key_value": "*", 'output_variable_name': "m"
+                }
+            },
+            'DemandManagerAssignmentList': {'DemandManagerAssignmentList 1': {"meter_name": "m"}},
+            'UtilityCost:Tariff': {'UtilityCost:Tariff 1': {"output_meter_name": "m"}},
+            'ElectricLoadCenter:Distribution': {'ElectricLoadCenter:Distribution 1': {
+                "generator_track_meter_scheme_meter_name": "m",
+                "storage_control_track_meter_name": "m"}
+            },
         }
         ov = OutputVariable({"m": "n"})
         updated_contents = ov.transform(file_contents, self.muted_logger)
@@ -113,6 +130,23 @@ class TestOutputVariableRule(unittest.TestCase):
             'Output:Meter:MeterFileOnly': {'Output:Meter:MeterFileOnly 1': {"key_name": "n"}},
             'Output:Meter:Cumulative': {'Output:Meter:Cumulative 1': {"key_name": "n"}},
             'Output:Meter:Cumulative:MeterFileOnly': {'Output:Meter:Cumulative:MeterFileOnly 1': {"key_name": "n"}},
+            'Output:Table:TimeBins': {'Output:Table:TimeBins 1': {"key_value": "*", 'variable_name': "n"}},
+            'ExternalInterface:FunctionalMockupUnitImport:From:Variable': {
+                'ExternalInterface:FunctionalMockupUnitImport:From:Variable 1': {
+                    "key_value": "*", 'output_variable_name': "n"
+                }
+            },
+            'ExternalInterface:FunctionalMockupUnitExport:From:Variable': {
+                'ExternalInterface:FunctionalMockupUnitExport:From:Variable 1': {
+                    "key_value": "*", 'output_variable_name': "n"
+                }
+            },
+            'DemandManagerAssignmentList': {'DemandManagerAssignmentList 1': {"meter_name": "n"}},
+            'UtilityCost:Tariff': {'UtilityCost:Tariff 1': {"output_meter_name": "n"}},
+            'ElectricLoadCenter:Distribution': {'ElectricLoadCenter:Distribution 1': {
+                "generator_track_meter_scheme_meter_name": "n",
+                "storage_control_track_meter_name": "n"}
+            },
         }
         self.assertDictEqual(expected_outputs, updated_contents)
 

--- a/tests/rules/test_common.py
+++ b/tests/rules/test_common.py
@@ -56,6 +56,49 @@ class TestOutputVariableRule(unittest.TestCase):
         expected_outputs['Output:Variable']['Output:Variable 3']['variable_name'] = "ALL UPPER CASE FOR FUN"
         self.assertDictEqual(expected_outputs, updated_contents)
 
+    def test_transform_some_ems_variables(self):
+        file_contents = {
+            'EnergyManagementSystem:Sensor': {
+                'EnergyManagementSystem:Sensor 1': {
+                    "output_variable_or_output_meter_index_key_name": "*",
+                    "output_variable_or_output_meter_name": "Site Outdoor Air Drybulb Temperature"
+                },
+                'EnergyManagementSystem:Sensor 2': {
+                    "output_variable_or_output_meter_index_key_name": "*",
+                    "output_variable_or_output_meter_name": "Boiler Inlet Temperature"
+                },
+                'EnergyManagementSystem:Sensor 3': {
+                    "output_variable_or_output_meter_index_key_name": "Plant Loop 1",
+                    "output_variable_or_output_meter_name": "Plant Supply Side Unmet Demand Rate"
+                },
+                'EnergyManagementSystem:Sensor 4': {
+                    "output_variable_or_output_meter_index_key_name": "Zone 1",
+                    "output_variable_or_output_meter_name": "Zone Mean Air Temperature"
+                }
+            }
+        }
+        ov = OutputVariable({
+            "Site Outdoor Air Drybulb Temperature": "New Outdoor TEMP",
+            "Plant Supply Side Unmet Demand Rate": "ALL UPPER CASE FOR FUN",
+            "Boiler Inlet Temperature": None,
+            "Zone Mean Air Temperature": ['A', 'B']
+        })
+        updated_contents = ov.transform(file_contents, self.muted_logger)
+        expected_outputs = file_contents
+        expected_outputs['EnergyManagementSystem:Sensor']['EnergyManagementSystem:Sensor 1'][
+            'output_variable_or_output_meter_name'] = "New Outdoor TEMP"
+        expected_outputs['EnergyManagementSystem:Sensor']['EnergyManagementSystem:Sensor 3'][
+            'output_variable_or_output_meter_name'] = "ALL UPPER CASE FOR FUN"
+        del expected_outputs['EnergyManagementSystem:Sensor']['EnergyManagementSystem:Sensor 2']
+        del expected_outputs['EnergyManagementSystem:Sensor']['EnergyManagementSystem:Sensor 4']
+        expected_outputs['EnergyManagementSystem:Sensor']['Zone Mean Air Temperature_1'] = {
+            'output_variable_or_output_meter_index_key_name': 'Zone 1', 'output_variable_or_output_meter_name': 'A'
+        }
+        expected_outputs['EnergyManagementSystem:Sensor']['Zone Mean Air Temperature_2'] = {
+            'output_variable_or_output_meter_index_key_name': 'Zone 1', 'output_variable_or_output_meter_name': 'B'
+        }
+        self.assertDictEqual(expected_outputs, updated_contents)
+
     def test_output_variable_is_deleted(self):
         file_contents = {
             'Output:Variable': {

--- a/tests/rules/test_common.py
+++ b/tests/rules/test_common.py
@@ -99,6 +99,23 @@ class TestOutputVariableRule(unittest.TestCase):
         }
         self.assertDictEqual(expected_outputs, updated_contents)
 
+    def test_transform_some_meters_variables(self):
+        file_contents = {
+            'Output:Meter': {'Output:Meter 1': {"key_name": "m"}},
+            'Output:Meter:MeterFileOnly': {'Output:Meter:MeterFileOnly 1': {"key_name": "m"}},
+            'Output:Meter:Cumulative': {'Output:Meter:Cumulative 1': {"key_name": "m"}},
+            'Output:Meter:Cumulative:MeterFileOnly': {'Output:Meter:Cumulative:MeterFileOnly 1': {"key_name": "m"}},
+        }
+        ov = OutputVariable({"m": "n"})
+        updated_contents = ov.transform(file_contents, self.muted_logger)
+        expected_outputs = {
+            'Output:Meter': {'Output:Meter 1': {"key_name": "n"}},
+            'Output:Meter:MeterFileOnly': {'Output:Meter:MeterFileOnly 1': {"key_name": "n"}},
+            'Output:Meter:Cumulative': {'Output:Meter:Cumulative 1': {"key_name": "n"}},
+            'Output:Meter:Cumulative:MeterFileOnly': {'Output:Meter:Cumulative:MeterFileOnly 1': {"key_name": "n"}},
+        }
+        self.assertDictEqual(expected_outputs, updated_contents)
+
     def test_output_variable_is_deleted(self):
         file_contents = {
             'Output:Variable': {

--- a/tests/rules/test_common.py
+++ b/tests/rules/test_common.py
@@ -55,3 +55,100 @@ class TestOutputVariableRule(unittest.TestCase):
         expected_outputs['Output:Variable']['Output:Variable 1']['variable_name'] = "New Outdoor TEMP"
         expected_outputs['Output:Variable']['Output:Variable 3']['variable_name'] = "ALL UPPER CASE FOR FUN"
         self.assertDictEqual(expected_outputs, updated_contents)
+
+    def test_output_variable_is_deleted(self):
+        file_contents = {
+            'Output:Variable': {
+                'Output:Variable 1': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "Site Outdoor Air Drybulb Temperature"
+                },
+                'Output:Variable 2': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "Boiler Inlet Temperature"
+                },
+                'Output:Variable 3': {
+                    "key_value": "Plant Loop 1",
+                    "reporting_frequency": "Daily",
+                    "variable_name": "Plant Supply Side Unmet Demand Rate"
+                }
+            }
+        }
+        ov = OutputVariable({
+            "Site Outdoor Air Drybulb Temperature": "New Outdoor TEMP",
+            "Boiler Inlet Temperature": None
+        })
+        updated_contents = ov.transform(file_contents, self.muted_logger)
+        expected_outputs = {
+            'Output:Variable': {
+                'Output:Variable 1': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "New Outdoor TEMP"
+                },
+                'Output:Variable 3': {
+                    "key_value": "Plant Loop 1",
+                    "reporting_frequency": "Daily",
+                    "variable_name": "Plant Supply Side Unmet Demand Rate"
+                }
+            }
+        }
+        self.assertDictEqual(expected_outputs, updated_contents)
+
+    def test_output_variable_is_list(self):
+        file_contents = {
+            'Output:Variable': {
+                'Output:Variable 1': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "Site Outdoor Air Drybulb Temperature"
+                },
+                'Output:Variable 2': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "Boiler Inlet Temperature"
+                },
+                'Output:Variable 3': {
+                    "key_value": "Plant Loop 1",
+                    "reporting_frequency": "Daily",
+                    "variable_name": "Plant Supply Side Unmet Demand Rate"
+                }
+            }
+        }
+        ov = OutputVariable({
+            "Site Outdoor Air Drybulb Temperature": "New Outdoor TEMP",
+            "Boiler Inlet Temperature": ['A', 'B', 'C']
+        })
+        updated_contents = ov.transform(file_contents, self.muted_logger)
+        expected_outputs = {
+            'Output:Variable': {
+                'Output:Variable 1': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "New Outdoor TEMP"
+                },
+                'Output:Variable 3': {
+                    "key_value": "Plant Loop 1",
+                    "reporting_frequency": "Daily",
+                    "variable_name": "Plant Supply Side Unmet Demand Rate"
+                },
+                'Boiler Inlet Temperature_1': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "A"
+                },
+                'Boiler Inlet Temperature_2': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "B"
+                },
+                'Boiler Inlet Temperature_3': {
+                    "key_value": "*",
+                    "reporting_frequency": "Hourly",
+                    "variable_name": "C"
+                },
+            }
+        }
+        self.assertDictEqual(expected_outputs, updated_contents)


### PR DESCRIPTION
Fixes a number of things, as of right now it will properly convert 9.5 files to 9.6.  There are some output variable related pieces missing from transition, including Output:Table:Monthly, Meter:Custom, and Meter:Custom:Decrement.  However, there aren't any output variables changed in 9.6 (so far), so it's still fine.  Anyway, this isn't a final version, and I'll try to keep this code up with E+ transition rules as 9.6 approaches.